### PR TITLE
Convert to mapping

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Chris Taylor chris@prosopo.io"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { git = "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
-ink_metadata = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false, features = ["derive"], optional = true }
-ink_env = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
-ink_storage = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
-ink_lang = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
-ink_prelude = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_primitives = { path = "/home/chris/dev/ink/crates/primitives", default-features = false }
+ink_metadata = { path = "/home/chris/dev/ink/crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "/home/chris/dev/ink/crates/env", default-features = false }
+ink_storage = { path = "/home/chris/dev/ink/crates/storage", default-features = false }
+ink_lang = { path = "/home/chris/dev/ink/crates/lang", default-features = false }
+ink_prelude = { path = "/home/chris/dev/ink/crates/prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
 [lib]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,21 +5,24 @@ authors = ["Chris Taylor chris@prosopo.io"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { git = "https://github.com/Supercolony-net/ink", branch = "optimizations/reworked-common-part-of-message", default-features = false }
-ink_metadata = { git = "https://github.com/Supercolony-net/ink", branch = "optimizations/reworked-common-part-of-message", default-features = false, features = ["derive"], optional = true }
-ink_env = { git = "https://github.com/Supercolony-net/ink", branch = "optimizations/reworked-common-part-of-message", default-features = false }
-ink_storage = { git = "https://github.com/Supercolony-net/ink", branch = "optimizations/reworked-common-part-of-message", default-features = false }
-ink_lang = { git = "https://github.com/Supercolony-net/ink", branch = "optimizations/reworked-common-part-of-message", default-features = false }
-ink_prelude = { git = "https://github.com/Supercolony-net/ink", branch = "optimizations/reworked-common-part-of-message", default-features = false }
+ink_primitives = { git = "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_metadata = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false, features = ["derive"], optional = true }
+ink_env = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_storage = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_lang = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_prelude = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
 [lib]
 name = "prosopo"
-path = "lib.rs"
+path =  "lib.rs"
 crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
+    # Used for normal contract Wasm blobs.
+    "cdylib",
 ]
+# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
+[profile.release]
+overflow-checks = false
 
 [features]
 default = ["std"]
@@ -31,7 +34,6 @@ std = [
     "ink_primitives/std",
     "scale/std",
     "scale-info/std",
-
 ]
 ink-as-dependency = []
 ink-experimental-engine = ["ink_env/ink-experimental-engine"]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Chris Taylor chris@prosopo.io"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { path = "/home/chris/dev/ink/crates/primitives", default-features = false }
-ink_metadata = { path = "/home/chris/dev/ink/crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { path = "/home/chris/dev/ink/crates/env", default-features = false }
-ink_storage = { path = "/home/chris/dev/ink/crates/storage", default-features = false }
-ink_lang = { path = "/home/chris/dev/ink/crates/lang", default-features = false }
-ink_prelude = { path = "/home/chris/dev/ink/crates/prelude", default-features = false }
+ink_primitives = { git = "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_metadata = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false, features = ["derive"], optional = true }
+ink_env = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_storage = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_lang = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
+ink_prelude = { git =  "https://github.com/prosopo-io/ink", branch = "spread_allocate_enum_default", default-features = false }
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
 [lib]

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -723,7 +723,6 @@ mod prosopo {
             let transferred = self.env().transferred_balance();
             if self.dapps.get(&contract).is_some() {
                 let mut dapp = self.dapps.get(&contract).unwrap();
-                ink_env::debug_println!("{:?}", dapp);
                 let total = dapp.balance + transferred;
                 dapp.balance = total;
                 if dapp.balance > 0 {
@@ -761,14 +760,13 @@ mod prosopo {
             let balance = dapp.balance;
             // TODO ensure that the dapp has no outstanding payments due
             if dapp.balance > 0 {
-                ink_env::debug_println!("Dapp Balance: {}", dapp.balance);
                 self.env().transfer(caller, dapp.balance).ok();
-                self.dapp_deregister(contract);
-                self.env().emit_event(DappCancel {
-                    contract,
-                    value: balance,
-                });
             }
+            self.dapp_deregister(contract);
+            self.env().emit_event(DappCancel {
+                contract,
+                value: balance,
+            });
 
             Ok(())
         }
@@ -1540,7 +1538,6 @@ mod prosopo {
             let dapp = contract.dapps.get(&contract_account).unwrap();
             assert_eq!(dapp.status, Status::Deactivated);
 
-            //ink_env::debug_println!("{:?}", InkString::from("blablabh"));
             // Make sure the funds are returned to the caller
             assert_eq!(dapp.balance, 0);
             let callers_balance =
@@ -1655,8 +1652,6 @@ mod prosopo {
             assert_eq!(commitment.status, Status::Approved);
             let new_dapp_balance = contract.get_dapp_balance(dapp_contract_account);
             let new_provider_balance = contract.get_provider_balance(provider_account);
-            ink_env::debug_println!("\nDapp Balance: {}", new_dapp_balance);
-            ink_env::debug_println!("Provider Balance: {}", new_provider_balance);
             assert_eq!(balance - Balance::from(fee), new_dapp_balance);
             assert_eq!(balance + Balance::from(fee), new_provider_balance);
 
@@ -1784,8 +1779,6 @@ mod prosopo {
             assert_eq!(commitment.status, Status::Disapproved);
             let new_dapp_balance = contract.get_dapp_balance(dapp_contract_account);
             let new_provider_balance = contract.get_provider_balance(provider_account);
-            ink_env::debug_println!("\nDapp Balance: {}", new_dapp_balance);
-            ink_env::debug_println!("Provider Balance: {}", new_provider_balance);
             assert_eq!(balance - Balance::from(fee), new_dapp_balance);
             assert_eq!(balance + Balance::from(fee), new_provider_balance);
 
@@ -1798,7 +1791,6 @@ mod prosopo {
             assert_eq!(commitment.status, Status::Disapproved);
             assert_eq!(balance - Balance::from(fee), contract.get_dapp_balance(dapp_contract_account));
             assert_eq!(balance + Balance::from(fee), contract.get_provider_balance(provider_account));
-            //ink_env::debug_println!("{:?}", contract.providers.values());
         }
 
         /// Test dapp user is human

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -1135,6 +1135,7 @@ mod prosopo {
             let fee: u32 = 0;
             contract.provider_register(service_origin, fee, Payee::Provider, provider_account);
             assert!(contract.providers.get(&provider_account).is_some());
+            assert!(contract.provider_accounts.contains(&provider_account));
         }
 
         /// Test provider deregister
@@ -1394,6 +1395,7 @@ mod prosopo {
             // account is marked as suspended as zero tokens have been paid
             assert_eq!(dapp.status, Status::Suspended);
             assert_eq!(dapp.balance, balance);
+            assert!(contract.dapp_accounts.contains(&dapp_contract));
         }
 
         /// Test dapp register with positive balance transfer
@@ -1425,6 +1427,7 @@ mod prosopo {
             // account is marked as active as balance is now positive
             assert_eq!(dapp.status, Status::Active);
             assert_eq!(dapp.balance, balance);
+            assert!(contract.dapp_accounts.contains(&dapp_contract));
         }
 
         /// Test dapp register and then update
@@ -1479,6 +1482,7 @@ mod prosopo {
             // account is marked as active as tokens have been paid
             assert_eq!(dapp.status, Status::Active);
             assert_eq!(dapp.balance, balance_1 + balance_2);
+            assert!(contract.dapp_accounts.contains(&dapp_contract_account));
         }
 
         /// Test dapp fund account

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -419,6 +419,7 @@ mod prosopo {
         /// Constructor
         #[ink(constructor)]
         pub fn default(operator: AccountId) -> Self {
+            ink_env::debug_println!("in the constructor!");
             ink_lang::codegen::initialize_contract(|contract| {
                 Self::new_init(contract, operator)
             })

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -431,6 +431,7 @@ mod prosopo {
         #[ink(constructor)]
         pub fn default(operator: AccountId) -> Self {
             ink_env::debug_println!("in the constructor!");
+
             ink_lang::codegen::initialize_contract(|contract| {
                 Self::new_init(contract, operator)
             })
@@ -442,6 +443,8 @@ mod prosopo {
             self.operators.insert(operator_account, operator);
             self.operator_accounts.push(operator_account);
         }
+
+
 
 
         /// Setup phase messages
@@ -1234,7 +1237,6 @@ mod prosopo {
                     "encountered unexpected event kind: expected a ProviderUpdate event: {:?}", decoded_event_update
                 );
             }
-
         }
 
         /// Test provider stake
@@ -1540,7 +1542,6 @@ mod prosopo {
             assert_eq!(dapp.balance, balance_1 + balance_2);
             assert!(contract.dapp_accounts.contains(&dapp_contract_account));
         }
-
 
 
         /// Test dapp fund account

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Prosopo (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use ink_lang as ink;

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -1118,6 +1118,17 @@ mod prosopo {
         use std::fmt::{Debug, Formatter};
 
         type Event = <Prosopo as ::ink_lang::reflect::ContractEventBase>::Type;
+        /// Test add operator
+        #[ink::test]
+        fn test_add_operator() {
+            let operator_account = AccountId::from([0x1; 32]);
+            let mut contract = Prosopo::default(operator_account);
+            ink_env::test::set_caller::<ink_env::DefaultEnvironment>(operator_account);
+            let operator_account_new = AccountId::from([0x2; 32]);
+            contract.add_prosopo_operator(operator_account_new);
+            assert!(contract.operator_accounts.contains(&operator_account_new));
+            assert!(contract.operators.get(&operator_account_new).is_some());
+        }
 
         /// Test provider register and update
         #[ink::test]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "yarn redspot compile",
     "test": "yarn redspot test",
     "explorer": "yarn redspot explorer",
-    "deploy": "npx --trace-warnings redspot run ./scripts/deploy.ts --release"
+    "deploy": "npx --trace-warnings redspot run ./scripts/deploy.ts"
   },
   "main": "index.js",
   "repository": "git@github.com:prosopo-io/protocol.git",


### PR DESCRIPTION

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/forgetso/4e3350c273f5173afc45b6ce74a97cb2/raw/protocol__pull_##.json)

Modifies storage so that Providers, Dapps and Operators are stored as `Vectors` of known keys and `Mappings`

Everything else is stored as a `Mapping` only (e.g. captcha solution commitments, captcha_data, dapp_users)

A forked version of `ink` was required for this work. Requires following feature request before moving back to main release:

https://github.com/paritytech/ink/issues/1042
